### PR TITLE
[globFilter Test Coverage] 

### DIFF
--- a/proto/dwtools/abase/l5.test/Glob.test.s
+++ b/proto/dwtools/abase/l5.test/Glob.test.s
@@ -310,42 +310,49 @@ function globFilter( test )
   let path = _.path;
 
   test.case = 'empty right glob';
+  test.description = 'empty selector';
   var expected = [];
   var src = [ 'abc', 'abd', 'adb', 'dbb', 'dab' ];
   var got = path.globFilter( src, '' );
   test.identical( got, expected );
 
   test.case = 'empty right glob';
+  test.description = 'selector out of league';
   var expected = [];
   var src = [ 'abc', 'abd', 'adb', 'dbb', 'dab' ];
   var got = path.globFilter( src, 'z*' );
   test.identical( got, expected );
 
   test.case = 'empty right glob';
+  test.description = 'selector starts with double out of league chars';
   var expected = [];
   var src = [ 'abc', 'abd', 'adb', 'dbb', 'dab' ];
   var got = path.globFilter( src, 'za*' );
   test.identical( got, expected );
 
   test.case = 'empty right glob';
+  test.description = 'selector ends with double out of league chars';
   var expected = [];
   var src = [ 'abc', 'abd', 'adb', 'dbb', 'dab' ];
   var got = path.globFilter( src, '*az' );
   test.identical( got, expected );
 
   test.case = 'empt right glob';
+  test.description = 'selector starts with unexpected char within the league';
   var expected = [];
   var src = [ 'abc', 'abd', 'adb', 'dbb', 'dab' ];
   var got = path.globFilter( src, 'b*' );
   test.identical( got, expected );
 
   test.case = 'empty right glob';
+  test.description = 'selector string length overflow';
   var expected = [];
   var src = [ 'abc', 'abd', 'adb', 'dbb', 'dab' ];
   var got = path.globFilter( src, 'dbba' );
   test.identical( got, expected );
 
   test.case = 'right glob';
+  test.description = 'selector string starts with d';
   var expected = [ 'dbb', 'dab' ];
   var src = [ 'abc', 'abd', 'adb', 'dbb', 'dab' ];
   var got = path.globFilter( src, 'd*' );

--- a/proto/dwtools/abase/l5.test/Glob.test.s
+++ b/proto/dwtools/abase/l5.test/Glob.test.s
@@ -338,7 +338,7 @@ function globFilter( test )
   var got = path.globFilter( src, '*az' );
   test.identical( got, expected );
 
-  test.case = 'empt right glob';
+  test.case = 'empty right glob';
   test.description = 'selector starts with unexpected char within the league';
   var expected = [];
   var src = [ 'abc', 'abd', 'adb', 'dbb', 'dab' ];
@@ -377,34 +377,22 @@ function globFilter( test )
   var got = path.globFilter( src, '*a*' );
   test.identical( got, expected );
 
+  test.case = 'mid glob double';
+  var expected = [ 'dbb', 'dbba' ];
+  var src = [ 'abc', 'abd', 'adb', 'dbb', 'dab', 'dbba' ];
+  var got = path.globFilter( src, '*bb*' );
+  test.identical( got, expected );
+
   test.case = 'not glob';
   var expected = [ 'abd' ];
   var src = [ 'abc', 'abd', 'adb' ];
   var got = path.globFilter( src, 'abd' );
   test.identical( got, expected );
 
-  test.case = 'repeat glob';
-  var expected = [ 'dbb' ];
-  var src = [ 'abc', 'abd', 'adb', 'dbb', 'dab' ];
-  var got = path.globFilter( src, '*bb' );
-  test.identical( got, expected );
-
   test.case = 'any glob';
   var expected = [ 'abc', 'abd', 'adb', 'dbb', 'dab' ];
   var src = [ 'abc', 'abd', 'adb', 'dbb', 'dab' ];
   var got = path.globFilter( src, '*' );
-  test.identical( got, expected );
-
-  test.case = 'right glob double b';
-  var expected = [ 'dbb' ];
-  var src = [ 'abc', 'abd', 'adb', 'dbb', 'dab', 'dbba' ];
-  var got = path.globFilter( src, '*bb' );
-  test.identical( got, expected );
-
-  test.case = 'right glob double middle b';
-  var expected = [ 'dbb', 'dbba' ];
-  var src = [ 'abc', 'abd', 'adb', 'dbb', 'dab', 'dbba' ];
-  var got = path.globFilter( src, '*bb*' );
   test.identical( got, expected );
 
   // ?
@@ -427,11 +415,43 @@ function globFilter( test )
   test.notIdentical( got, expected );
 
   // ? & *
-
   test.case = 'right glob len = atleast 2 chars';
   var expected = [ 'ab', 'ad', 'ac', 'abc', 'adb', 'acb' ];
   var src = [ 'ab', 'ad', 'ac', 'abc', 'adb', 'acb' ];
   var got = path.globFilter( src, 'a?*' );
+  test.identical( got, expected );
+
+  // [...]
+  // test.case = 'glob range';
+  // var expected = [ 'abcdefg' ];
+  // var src = [ 'abc', 'abcd', 'abcde', 'abcdef', 'abcdefg' ];
+  // var got = path.globFilter( src, '[a..g]' );
+  // test.identical( got, expected );
+
+  // |
+
+  test.case = 'pattern match = none';
+  var expected = [ ];
+  var src = [ 'a', 'b', 'bb' ];
+  var got = path.globFilter( src, 'a(b|bb|bc)' );
+  test.identical( got, expected );
+
+  test.case = 'pattern match = all ending with c';
+  var expected = [ 'abcc' ];
+  var src = [ 'abcc', 'bc', 'ac' ];
+  var got = path.globFilter( src, '(ab|bb|abc)c' );
+  test.identical( got, expected );
+
+  test.case = 'pattern match = none';
+  var expected = [ ];
+  var src = [ 'a', 'b', 'bb' ];
+  var got = path.globFilter( src, 'a(b|bb|bc)' );
+  test.identical( got, expected );
+
+  test.case = 'either a or b but ending with c';
+  var expected = [ 'ac' ];
+  var src = [ 'ac', 'abc', 'cc' ];
+  var got = path.globFilter( src, '(a|b)c' );
   test.identical( got, expected );
 
 }

--- a/proto/dwtools/abase/l5.test/Glob.test.s
+++ b/proto/dwtools/abase/l5.test/Glob.test.s
@@ -416,7 +416,7 @@ function globFilter( test )
   test.identical( got, expected );
 
   // Range 
-  test.case = 'empty glob for group of digits';
+  test.case = 'empty char glob for group of digits';
   var expected = [ ];
   var src = [ 1, 2, 3, 4, 5, 123, 456, 123456, 7890];
   var got = path.globFilter( src, '+([a-g])' );
@@ -424,17 +424,29 @@ function globFilter( test )
 
   test.case = 'glob range group of chars';
   var expected = [ 'abc', 'abcd', 'abcde', 'abcdef', 'abcdefg', 'a' ];
-  var src = [ 'abc', 'abcd', 'abcde', 'abcdef', 'abcdefg', 'a', 1 ];
+  var src = [ 'abc', 'abcd', 'abcde', 'abcdef', 'abcdefg', 'a', 1, 'xyz', 'abcdefghij' ];
   var got = path.globFilter( src, '+([a-g])' );
   test.identical( got, expected );
 
-  test.case = 'empty glob for group of digits';
+  test.case = 'glob range group of chars and must have more trailing';
+  var expected = [ 'abc', 'abcd', 'abcde', 'abcdef', 'abcdefg', 'abcdefghij'];
+  var src = [ 'abc', 'abcd', 'abcde', 'abcdef', 'abcdefg', 'a', 1, 'xyz', 'abcdefghij' ];
+  var got = path.globFilter( src, '+([a-g])+([a-z])' );
+  test.identical( got, expected );
+
+  test.case = 'glob range group of chars and may have more trailing';
+  var expected = [ 'abc', 'abcd', 'abcde', 'abcdef', 'abcdefg', 'a', 'abcdefghij'];
+  var src = [ 'abc', 'abcd', 'abcde', 'abcdef', 'abcdefg', 'a', 1, 'xyz', 'abcdefghij' ];
+  var got = path.globFilter( src, '+([a-g])*([a-z])' );
+  test.identical( got, expected );
+
+  test.case = 'empty digit glob for group of unexpected chars';
   var expected = [ ];
   var src = [ 'abc', 'abcd', 'abcde', 'abcdef', 'abcdefg', 'a' ];
   var got = path.globFilter( src, '+([0-9])' );
   test.identical( got, expected );
 
-  test.case = 'glob for group of digits';
+  test.case = 'digit glob for group of digits';
   var expected = [ 1, 2, 3, 4, 5, 123, 456, 123456, 7890 ];
   var src = [ 1, 2, 3, 4, 5, 123, 456, 123456, 7890, 'a', 'abc' ];
   var got = path.globFilter( src, '+([0-9])' );

--- a/proto/dwtools/abase/l5.test/Glob.test.s
+++ b/proto/dwtools/abase/l5.test/Glob.test.s
@@ -317,55 +317,55 @@ function globFilter( test )
   var got = path.globFilter( src, '' );
   test.identical( got, expected );
 
-  test.case = 'empty right glob';
+  test.case = 'mandatory single char followed by * that should never be found';
   test.description = 'selector out of league';
   var expected = [];
   var src = [ 'abc', 'abd', 'adb', 'dbb', 'dab' ];
   var got = path.globFilter( src, 'z*' );
   test.identical( got, expected );
 
-  test.case = 'empty right glob';
+  test.case = '* followed by mandatory char that should never be found';
+  var expected = [];
+  var src = [ 'abc', 'abd', 'adb', 'dbb', 'dab' ];
+  var got = path.globFilter( src, '*a' );
+  test.identical( got, expected );
+
+  test.case = 'mandatory double char followed by * that should never be found';
   test.description = 'selector starts with double out of league chars';
   var expected = [];
   var src = [ 'abc', 'abd', 'adb', 'dbb', 'dab' ];
   var got = path.globFilter( src, 'za*' );
   test.identical( got, expected );
 
-  test.case = 'empty right glob';
+  test.case = '* followed by mandatory double char that should never be found';
   test.description = 'selector ends with double out of league chars';
   var expected = [];
   var src = [ 'abc', 'abd', 'adb', 'dbb', 'dab' ];
   var got = path.globFilter( src, '*az' );
   test.identical( got, expected );
 
-  test.case = 'empty right glob';
-  test.description = 'selector starts with unexpected char within the league';
-  var expected = [];
-  var src = [ 'abc', 'abd', 'adb', 'dbb', 'dab' ];
-  var got = path.globFilter( src, 'b*' );
-  test.identical( got, expected );
-
-  test.case = 'empty right glob';
+  test.case = 'plain mandatory string that should never be found';
   test.description = 'selector string length overflow';
   var expected = [];
   var src = [ 'abc', 'abd', 'adb', 'dbb', 'dab' ];
   var got = path.globFilter( src, 'dbba' );
   test.identical( got, expected );
+ 
+  test.case = 'plain mandatory string that should be found';
+  test.description = 'selector string length overflow';
+  var expected = [ 'dbb' ];
+  var src = [ 'abc', 'abd', 'adb', 'dbb', 'dab' ];
+  var got = path.globFilter( src, 'dbb' );
+  test.identical( got, expected );
 
-  test.case = 'right glob';
+  test.case = 'mandatory char followed by * that should be found';
   test.description = 'selector string starts with d';
   var expected = [ 'dbb', 'dab' ];
   var src = [ 'abc', 'abd', 'adb', 'dbb', 'dab' ];
   var got = path.globFilter( src, 'd*' );
   test.identical( got, expected );
 
-  test.case = 'empty left glob';
-  var expected = [];
-  var src = [ 'abc', 'abd', 'adb', 'dbb', 'dab' ];
-  var got = path.globFilter( src, '*a' );
-  test.identical( got, expected );
-
-  test.case = 'left glob';
+  test.case = '* followed by mandatory char that should be found';
   var expected = [ 'adb', 'dbb', 'dab' ];
   var src = [ 'abc', 'abd', 'adb', 'dbb', 'dab' ];
   var got = path.globFilter( src, '*b' );
@@ -555,6 +555,7 @@ function globFilter( test )
   test.case = 'plain numbers as glob must fail';
   var src = [ 0, 1, 2, 3, 4 ];
   test.shouldThrowErrorSync( path.globFilter( src, 0 ) );
+
 }
 
 //

--- a/proto/dwtools/abase/l5.test/Glob.test.s
+++ b/proto/dwtools/abase/l5.test/Glob.test.s
@@ -501,32 +501,46 @@ function globFilter( test )
   test.case = 'not pattern match = none';
   var expected = [ ];
   var src = [ 'ab', 'ac' ];
-  var got = path.globFilter( src, 'a!(b|c)' );
-  test.identical( got, expected );
+  var got1 = path.globFilter( src, 'a!(b|c)' );
+  var got2 = path.globFilter( src, 'a^(b|c)' );
+  test.identical( got1, expected );
+  test.identical( got2, expected );
 
   test.case = '3 chars starting with a, skip b-k, end with z';
   var expected = [ 'azz' ];
   var src = [ 'abz', 'acz', 'azz' ];
-  var got = path.globFilter( src, 'a!(b|c|d|e|f|g|h|i|j|k)z' );
-  test.identical( got, expected );
+  var got1 = path.globFilter( src, 'a!(b|c|d|e|f|g|h|i|j|k)z' );
+  // FIXME: fails when there is a trailing z character after skipping pattern
+  var got2 = path.globFilter( src, 'a^(b|c|d|e|f|g|h|i|j|k)z' );
+  test.identical( got1, expected );
+  test.identical( got2, expected );
 
   test.case = 'any 3 chars, no z in the middle';
   var expected = [ 'abz', 'acz' ];
   var src = [ 'abz', 'acz', 'zzz' ];
-  var got = path.globFilter( src, 'a!(z)z' );
-  test.identical( got, expected );
+  var got1 = path.globFilter( src, 'a!(z)z' );
+  // FIXME: fails when there is a trailing z character after skipping pattern
+  var got2 = path.globFilter( src, 'a^(z)z' );
+  test.identical( got1, expected );
+  test.identical( got2, expected );
 
   test.case = 'any 3 chars, no xyz in the middle';
   var expected = [ 'abz', 'acz' ];
   var src = [ 'abz', 'acz', 'zzz' ];
-  var got = path.globFilter( src, 'a!(xyz)z' );
-  test.identical( got, expected );
+  var got1 = path.globFilter( src, 'a!(xyz)z' );
+  // FIXME: fails when there is a trailing z character after skipping pattern
+  var got2 = path.globFilter( src, 'a^(xyz)z' );
+  test.identical( got1, expected );
+  test.identical( got2, expected );
 
   test.case = 'skip a group of chars';
   var expected = [ 'car', 'cat', 'carpool', 'ca' ];
   var src = [ 'car', 'cat', 'catastrophic', 'carnage', 'carpool', 'ca' ];
-  var got = path.globFilter( src, 'ca!(tastrophic|rnage)' );
-  test.identical( got, expected );
+  var got1 = path.globFilter( src, 'ca!(tastrophic|rnage)' );
+  // FIXME: fails when ^ is preceeded by more than one chars
+  var got2 = path.globFilter( src, 'ca^(tastrophic|rnage)' );
+  test.identical( got1, expected );
+  test.identical( got2, expected );
 
   // @
   test.case = 'match exactly one of the patterns';

--- a/proto/dwtools/abase/l5.test/Glob.test.s
+++ b/proto/dwtools/abase/l5.test/Glob.test.s
@@ -408,12 +408,6 @@ function globFilter( test )
   var got = path.globFilter( src, 'a?' );
   test.identical( got, expected );
 
-  test.case = 'right glob len=2 not identical to left glob len=3';
-  var expected = [ 'abc', 'adb', 'acb' ];
-  var src = [ 'ab', 'ad', 'ac', 'abc', 'adb', 'acb' ];
-  var got = path.globFilter( src, 'a?' );
-  test.notIdentical( got, expected );
-
   // ? & *
   test.case = 'right glob len = atleast 2 chars';
   var expected = [ 'ab', 'ad', 'ac', 'abc', 'adb', 'acb' ];
@@ -448,6 +442,18 @@ function globFilter( test )
   var got = path.globFilter( src, '(a|b)c' );
   test.identical( got, expected );
 
+  test.case = 'pattern with single group';
+  var expected = [ 'axyzz' ];
+  var src = [ 'axyzz', 'adefz', 'azyxz' ];
+  var got = path.globFilter( src, 'a+(xyz)z' );
+  test.identical( got, expected );
+
+  test.case = 'pattern with 2 groups';
+  var expected = [ 'axyzz', 'adefz' ];
+  var src = [ 'abz', 'acz', 'zzz', 'axyzz', 'adefz' ];
+  var got = path.globFilter( src, 'a+(xyz|def)z' );
+  test.identical( got, expected );
+
   // !(|)
 
   test.case = 'not pattern match = none';
@@ -468,10 +474,16 @@ function globFilter( test )
   var got = path.globFilter( src, 'a!(z)z' );
   test.identical( got, expected );
 
-  test.case = 'not pattern match = skip all from a to k';
+  test.case = 'any 3 chars, no z in the middle';
   var expected = [ 'abz', 'acz' ];
-  var src = [ 'abz', 'acz', 'azz' ];
-  var got = path.globFilter( src, 'a!(z)z' );
+  var src = [ 'abz', 'acz', 'zzz' ];
+  var got = path.globFilter( src, 'a!(xyz)z' );
+  test.identical( got, expected );
+
+  test.case = 'skip a group of chars';
+  var expected = [ 'car', 'cat', 'carpool' ];
+  var src = [ 'car', 'cat', 'catastrophic', 'carnage', 'carpool' ];
+  var got = path.globFilter( src, 'ca!(trophic|nage)' );
   test.identical( got, expected );
 
 }

--- a/proto/dwtools/abase/l5.test/Glob.test.s
+++ b/proto/dwtools/abase/l5.test/Glob.test.s
@@ -538,11 +538,11 @@ function globFilter( test )
   // FIXME: Everything below this line
   test.case = 'must throw errors';
   var src = [ 'car', 'cat', 'catastrophic', 'carnage', 'carpool', 'ca' ];
-  test.shouldThrowError(path.globFilter());
-  test.shouldThrowError(path.globFilter( src ));
-  test.shouldThrowError(path.globFilter( src, null ));
-  test.shouldThrowError(path.globFilter( null, 'lorem' ));
-  test.shouldThrowError(path.globFilter( null, null ));
+  test.shouldThrowErrorSync(path.globFilter());
+  test.shouldThrowErrorSync(path.globFilter( src ));
+  test.shouldThrowErrorSync(path.globFilter( src, null ));
+  test.shouldThrowErrorSync(path.globFilter( null, 'lorem' ));
+  test.shouldThrowErrorSync(path.globFilter( null, null ));
 
   test.case = 'plain number';
   var expected = [ 0 ];

--- a/proto/dwtools/abase/l5.test/Glob.test.s
+++ b/proto/dwtools/abase/l5.test/Glob.test.s
@@ -440,6 +440,14 @@ function globFilter( test )
   var got = path.globFilter( src, '+([a-g])*([a-z])' );
   test.identical( got, expected );
 
+  test.case = 'glob range skip - (!)';
+  var expected = [ 1, 'xyz', 'abcdefghij' ];
+  var src = [ 'abc', 'abcd', 'abcde', 'abcdef', 'abcdefg', 'a', 1, 'xyz', 'abcdefghij' ];
+  var got1 = path.globFilter( src, '*[!a-g]' );
+  var got2 = path.globFilter( src, '*[^a-g]' );
+  test.identical( got1, expected );
+  test.identical( got2, expected );
+
   // |
   test.case = 'pattern match = none';
   var expected = [ ];
@@ -502,45 +510,31 @@ function globFilter( test )
   var expected = [ ];
   var src = [ 'ab', 'ac' ];
   var got1 = path.globFilter( src, 'a!(b|c)' );
-  var got2 = path.globFilter( src, 'a^(b|c)' );
   test.identical( got1, expected );
-  test.identical( got2, expected );
 
   test.case = '3 chars starting with a, skip b-k, end with z';
   var expected = [ 'azz' ];
   var src = [ 'abz', 'acz', 'azz' ];
-  var got1 = path.globFilter( src, 'a!(b|c|d|e|f|g|h|i|j|k)z' );
-  // FIXME: fails when there is a trailing z character after skipping pattern
-  var got2 = path.globFilter( src, 'a^(b|c|d|e|f|g|h|i|j|k)z' );
-  test.identical( got1, expected );
-  test.identical( got2, expected );
+  var got = path.globFilter( src, 'a!(b|c|d|e|f|g|h|i|j|k)z' );
+  test.identical( got, expected );
 
   test.case = 'any 3 chars, no z in the middle';
   var expected = [ 'abz', 'acz' ];
   var src = [ 'abz', 'acz', 'zzz' ];
-  var got1 = path.globFilter( src, 'a!(z)z' );
-  // FIXME: fails when there is a trailing z character after skipping pattern
-  var got2 = path.globFilter( src, 'a^(z)z' );
-  test.identical( got1, expected );
-  test.identical( got2, expected );
+  var got = path.globFilter( src, 'a!(z)z' );
+  test.identical( got, expected );
 
   test.case = 'any 3 chars, no xyz in the middle';
   var expected = [ 'abz', 'acz' ];
   var src = [ 'abz', 'acz', 'zzz' ];
-  var got1 = path.globFilter( src, 'a!(xyz)z' );
-  // FIXME: fails when there is a trailing z character after skipping pattern
-  var got2 = path.globFilter( src, 'a^(xyz)z' );
-  test.identical( got1, expected );
-  test.identical( got2, expected );
+  var got = path.globFilter( src, 'a!(xyz)z' );
+  test.identical( got, expected );
 
   test.case = 'skip a group of chars';
   var expected = [ 'car', 'cat', 'carpool', 'ca' ];
   var src = [ 'car', 'cat', 'catastrophic', 'carnage', 'carpool', 'ca' ];
-  var got1 = path.globFilter( src, 'ca!(tastrophic|rnage)' );
-  // FIXME: fails when ^ is preceeded by more than one chars
-  var got2 = path.globFilter( src, 'ca^(tastrophic|rnage)' );
-  test.identical( got1, expected );
-  test.identical( got2, expected );
+  var got = path.globFilter( src, 'ca!(tastrophic|rnage)' );
+  test.identical( got, expected );
 
   // @
   test.case = 'match exactly one of the patterns';

--- a/proto/dwtools/abase/l5.test/Glob.test.s
+++ b/proto/dwtools/abase/l5.test/Glob.test.s
@@ -415,7 +415,7 @@ function globFilter( test )
   var got = path.globFilter( src, 'a?*' );
   test.identical( got, expected );
 
-  // Range 
+  // (...)
   test.case = 'empty char glob for group of digits';
   var expected = [ ];
   var src = [ 1, 2, 3, 4, 5, 123, 456, 123456, 7890];
@@ -440,18 +440,6 @@ function globFilter( test )
   var got = path.globFilter( src, '+([a-g])*([a-z])' );
   test.identical( got, expected );
 
-  test.case = 'empty digit glob for group of unexpected chars';
-  var expected = [ ];
-  var src = [ 'abc', 'abcd', 'abcde', 'abcdef', 'abcdefg', 'a' ];
-  var got = path.globFilter( src, '+([0-9])' );
-  test.identical( got, expected );
-
-  test.case = 'digit glob for group of digits';
-  var expected = [ 1, 2, 3, 4, 5, 123, 456, 123456, 7890 ];
-  var src = [ 1, 2, 3, 4, 5, 123, 456, 123456, 7890, 'a', 'abc' ];
-  var got = path.globFilter( src, '+([0-9])' );
-  test.identical( got, expected );
-
   // |
   test.case = 'pattern match = none';
   var expected = [ ];
@@ -471,6 +459,7 @@ function globFilter( test )
   var got = path.globFilter( src, '(a|b)c' );
   test.identical( got, expected );
 
+  // +(|)
   test.case = 'pattern with single group';
   var expected = [ 'axyzz' ];
   var src = [ 'axyzz', 'adefz', 'azyxz' ];
@@ -483,8 +472,32 @@ function globFilter( test )
   var got = path.globFilter( src, 'a+(xyz|def)z' );
   test.identical( got, expected );
 
-  // !(|)
+  test.case = 'empty digit glob for group of unexpected chars';
+  var expected = [ ];
+  var src = [ 'abc', 'abcd', 'abcde', 'abcdef', 'abcdefg', 'a' ];
+  var got = path.globFilter( src, '+([0-9])' );
+  test.identical( got, expected );
 
+  test.case = 'digit glob for group of digits';
+  var expected = [ 1, 2, 3, 4, 5, 123, 456, 123456, 7890 ];
+  var src = [ 1, 2, 3, 4, 5, 123, 456, 123456, 7890, 'a', 'abc' ];
+  var got = path.globFilter( src, '+([0-9])' );
+  test.identical( got, expected );
+ 
+  // *(|)
+  test.case = 'empty digit glob for group of unexpected chars';
+  var expected = [ ];
+  var src = [ 'abc', 'abcd', 'abcde', 'abcdef', 'abcdefg', 'a' ];
+  var got = path.globFilter( src, '*([0-9])' );
+  test.identical( got, expected );
+
+  test.case = 'all strings that owns a car';
+  var expected = [ 'car', 'cart', 'carting', 'cariter' ];
+  var src = [ 'car', 'cart', 'carting', 'cariter' ];
+  var got = path.globFilter( src, 'car*(t|ting|iter)' );
+  test.identical( got, expected );
+
+  // !(|)
   test.case = 'not pattern match = none';
   var expected = [ ];
   var src = [ 'ab', 'ac' ];

--- a/proto/dwtools/abase/l5.test/Glob.test.s
+++ b/proto/dwtools/abase/l5.test/Glob.test.s
@@ -416,7 +416,7 @@ function globFilter( test )
   test.identical( got, expected );
 
   // (...)
-  test.case = 'empty char glob for group of digits';
+  test.case = 'empty char glob for a group of digits';
   var expected = [ ];
   var src = [ 1, 2, 3, 4, 5, 123, 456, 123456, 7890];
   var got = path.globFilter( src, '+([a-g])' );
@@ -453,7 +453,7 @@ function globFilter( test )
   var got = path.globFilter( src, '(ab|bb|abc)c' );
   test.identical( got, expected );
 
-  test.case = '2 chars starting with a or b but ending with c';
+  test.case = '2 chars starting with either a or b but ending with c';
   var expected = [ 'ac' ];
   var src = [ 'ac', 'abc', 'cc' ];
   var got = path.globFilter( src, '(a|b)c' );
@@ -516,18 +516,39 @@ function globFilter( test )
   var got = path.globFilter( src, 'a!(z)z' );
   test.identical( got, expected );
 
-  test.case = 'any 3 chars, no z in the middle';
+  test.case = 'any 3 chars, no xyz in the middle';
   var expected = [ 'abz', 'acz' ];
   var src = [ 'abz', 'acz', 'zzz' ];
   var got = path.globFilter( src, 'a!(xyz)z' );
   test.identical( got, expected );
 
   test.case = 'skip a group of chars';
-  var expected = [ 'car', 'cat', 'carpool' ];
-  var src = [ 'car', 'cat', 'catastrophic', 'carnage', 'carpool' ];
+  var expected = [ 'car', 'cat', 'carpool', 'ca' ];
+  var src = [ 'car', 'cat', 'catastrophic', 'carnage', 'carpool', 'ca' ];
   var got = path.globFilter( src, 'ca!(tastrophic|rnage)' );
   test.identical( got, expected );
 
+  // @
+  test.case = 'match exactly one of the patterns';
+  var expected = [ 'catastrophic', 'carnage' ];
+  var src = [ 'car', 'cat', 'catastrophic', 'carnage', 'carpool', 'ca' ];
+  var got = path.globFilter( src, 'ca@(tastrophic|rnage)' );
+  test.identical( got, expected );
+
+  // FIXME: Everything below this line
+  test.case = 'must throw errors';
+  var src = [ 'car', 'cat', 'catastrophic', 'carnage', 'carpool', 'ca' ];
+  test.shouldThrowError(path.globFilter());
+  test.shouldThrowError(path.globFilter( src ));
+  test.shouldThrowError(path.globFilter( src, null ));
+  test.shouldThrowError(path.globFilter( null, 'lorem' ));
+  test.shouldThrowError(path.globFilter( null, null ));
+
+  test.case = 'plain number';
+  var expected = [ 0 ];
+  var src = [ 0, 1, 2, 3, 4 ];
+  var got = path.globFilter( src, 0 );
+  test.identical( got, expected );
 }
 
 //

--- a/proto/dwtools/abase/l5.test/Glob.test.s
+++ b/proto/dwtools/abase/l5.test/Glob.test.s
@@ -309,6 +309,7 @@ function globFilter( test )
 {
   let path = _.path;
 
+  // *
   test.case = 'empty right glob';
   test.description = 'empty selector';
   var expected = [];
@@ -358,7 +359,7 @@ function globFilter( test )
   var got = path.globFilter( src, 'd*' );
   test.identical( got, expected );
 
-  test.case = 'empy left glob';
+  test.case = 'empty left glob';
   var expected = [];
   var src = [ 'abc', 'abd', 'adb', 'dbb', 'dab' ];
   var got = path.globFilter( src, '*a' );
@@ -404,6 +405,33 @@ function globFilter( test )
   var expected = [ 'dbb', 'dbba' ];
   var src = [ 'abc', 'abd', 'adb', 'dbb', 'dab', 'dbba' ];
   var got = path.globFilter( src, '*bb*' );
+  test.identical( got, expected );
+
+  // ?
+  test.case = 'glob match exact 1 char with string len=3';
+  var expected = [ 'dbb', 'dab' ];
+  var src = [ 'abc', 'abd', 'adb', 'dbb', 'dab', 'dbba' ];
+  var got = path.globFilter( src, 'd?b' );
+  test.identical( got, expected );
+
+  test.case = 'glob match exact 1 char with string len=2';
+  var expected = [ 'ab', 'ad', 'ac' ];
+  var src = [ 'ab', 'ad', 'ac', 'abc', 'adb', 'acb' ];
+  var got = path.globFilter( src, 'a?' );
+  test.identical( got, expected );
+
+  test.case = 'right glob len=2 not identical to left glob len=3';
+  var expected = [ 'abc', 'adb', 'acb' ];
+  var src = [ 'ab', 'ad', 'ac', 'abc', 'adb', 'acb' ];
+  var got = path.globFilter( src, 'a?' );
+  test.notIdentical( got, expected );
+
+  // ? & *
+
+  test.case = 'right glob len=2 not identical to left glob len=3';
+  var expected = [ 'ab', 'ad', 'ac', 'abc', 'adb', 'acb' ];
+  var src = [ 'ab', 'ad', 'ac', 'abc', 'adb', 'acb' ];
+  var got = path.globFilter( src, 'a?*' );
   test.identical( got, expected );
 
 }

--- a/proto/dwtools/abase/l5.test/Glob.test.s
+++ b/proto/dwtools/abase/l5.test/Glob.test.s
@@ -415,15 +415,32 @@ function globFilter( test )
   var got = path.globFilter( src, 'a?*' );
   test.identical( got, expected );
 
-  // For ranges [,] works and not [...]
-  test.case = 'glob range';
-  var expected = [ 'abcdefg' ];
-  var src = [ 'abc', 'abcd', 'abcde', 'abcdef', 'abcdefg', '' ];
-  var got = path.globFilter( src, '*[a,g]' );
+  // Range 
+  test.case = 'empty glob for group of digits';
+  var expected = [ ];
+  var src = [ 1, 2, 3, 4, 5, 123, 456, 123456, 7890];
+  var got = path.globFilter( src, '+([a-g])' );
+  test.identical( got, expected );
+
+  test.case = 'glob range group of chars';
+  var expected = [ 'abc', 'abcd', 'abcde', 'abcdef', 'abcdefg', 'a' ];
+  var src = [ 'abc', 'abcd', 'abcde', 'abcdef', 'abcdefg', 'a', 1 ];
+  var got = path.globFilter( src, '+([a-g])' );
+  test.identical( got, expected );
+
+  test.case = 'empty glob for group of digits';
+  var expected = [ ];
+  var src = [ 'abc', 'abcd', 'abcde', 'abcdef', 'abcdefg', 'a' ];
+  var got = path.globFilter( src, '+([0-9])' );
+  test.identical( got, expected );
+
+  test.case = 'glob for group of digits';
+  var expected = [ 1, 2, 3, 4, 5, 123, 456, 123456, 7890 ];
+  var src = [ 1, 2, 3, 4, 5, 123, 456, 123456, 7890, 'a', 'abc' ];
+  var got = path.globFilter( src, '+([0-9])' );
   test.identical( got, expected );
 
   // |
-
   test.case = 'pattern match = none';
   var expected = [ ];
   var src = [ 'a', 'b', 'bb' ];
@@ -483,7 +500,7 @@ function globFilter( test )
   test.case = 'skip a group of chars';
   var expected = [ 'car', 'cat', 'carpool' ];
   var src = [ 'car', 'cat', 'catastrophic', 'carnage', 'carpool' ];
-  var got = path.globFilter( src, 'ca!(trophic|nage)' );
+  var got = path.globFilter( src, 'ca!(tastrophic|rnage)' );
   test.identical( got, expected );
 
 }

--- a/proto/dwtools/abase/l5.test/Glob.test.s
+++ b/proto/dwtools/abase/l5.test/Glob.test.s
@@ -309,10 +309,40 @@ function globFilter( test )
 {
   let path = _.path;
 
+  test.case = 'empty right glob';
+  var expected = [];
+  var src = [ 'abc', 'abd', 'adb', 'dbb', 'dab' ];
+  var got = path.globFilter( src, '' );
+  test.identical( got, expected );
+
+  test.case = 'empty right glob';
+  var expected = [];
+  var src = [ 'abc', 'abd', 'adb', 'dbb', 'dab' ];
+  var got = path.globFilter( src, 'z*' );
+  test.identical( got, expected );
+
+  test.case = 'empty right glob';
+  var expected = [];
+  var src = [ 'abc', 'abd', 'adb', 'dbb', 'dab' ];
+  var got = path.globFilter( src, 'za*' );
+  test.identical( got, expected );
+
+  test.case = 'empty right glob';
+  var expected = [];
+  var src = [ 'abc', 'abd', 'adb', 'dbb', 'dab' ];
+  var got = path.globFilter( src, '*az' );
+  test.identical( got, expected );
+
   test.case = 'empt right glob';
   var expected = [];
   var src = [ 'abc', 'abd', 'adb', 'dbb', 'dab' ];
   var got = path.globFilter( src, 'b*' );
+  test.identical( got, expected );
+
+  test.case = 'empty right glob';
+  var expected = [];
+  var src = [ 'abc', 'abd', 'adb', 'dbb', 'dab' ];
+  var got = path.globFilter( src, 'dbba' );
   test.identical( got, expected );
 
   test.case = 'right glob';
@@ -343,6 +373,30 @@ function globFilter( test )
   var expected = [ 'abd' ];
   var src = [ 'abc', 'abd', 'adb' ];
   var got = path.globFilter( src, 'abd' );
+  test.identical( got, expected );
+
+  test.case = 'repeat glob';
+  var expected = [ 'dbb' ];
+  var src = [ 'abc', 'abd', 'adb', 'dbb', 'dab' ];
+  var got = path.globFilter( src, '*bb' );
+  test.identical( got, expected );
+
+  test.case = 'any glob';
+  var expected = [ 'abc', 'abd', 'adb', 'dbb', 'dab' ];
+  var src = [ 'abc', 'abd', 'adb', 'dbb', 'dab' ];
+  var got = path.globFilter( src, '*' );
+  test.identical( got, expected );
+
+  test.case = 'right glob double b';
+  var expected = [ 'dbb' ];
+  var src = [ 'abc', 'abd', 'adb', 'dbb', 'dab', 'dbba' ];
+  var got = path.globFilter( src, '*bb' );
+  test.identical( got, expected );
+
+  test.case = 'right glob double middle b';
+  var expected = [ 'dbb', 'dbba' ];
+  var src = [ 'abc', 'abd', 'adb', 'dbb', 'dab', 'dbba' ];
+  var got = path.globFilter( src, '*bb*' );
   test.identical( got, expected );
 
 }

--- a/proto/dwtools/abase/l5.test/Glob.test.s
+++ b/proto/dwtools/abase/l5.test/Glob.test.s
@@ -415,12 +415,12 @@ function globFilter( test )
   var got = path.globFilter( src, 'a?*' );
   test.identical( got, expected );
 
-  // [...]
-  // test.case = 'glob range';
-  // var expected = [ 'abcdefg' ];
-  // var src = [ 'abc', 'abcd', 'abcde', 'abcdef', 'abcdefg' ];
-  // var got = path.globFilter( src, '[a..g]' );
-  // test.identical( got, expected );
+  // For ranges [,] works and not [...]
+  test.case = 'glob range';
+  var expected = [ 'abcdefg' ];
+  var src = [ 'abc', 'abcd', 'abcde', 'abcdef', 'abcdefg', '' ];
+  var got = path.globFilter( src, '*[a,g]' );
+  test.identical( got, expected );
 
   // |
 

--- a/proto/dwtools/abase/l5.test/Glob.test.s
+++ b/proto/dwtools/abase/l5.test/Glob.test.s
@@ -428,7 +428,7 @@ function globFilter( test )
 
   // ? & *
 
-  test.case = 'right glob len=2 not identical to left glob len=3';
+  test.case = 'right glob len = atleast 2 chars';
   var expected = [ 'ab', 'ad', 'ac', 'abc', 'adb', 'acb' ];
   var src = [ 'ab', 'ad', 'ac', 'abc', 'adb', 'acb' ];
   var got = path.globFilter( src, 'a?*' );

--- a/proto/dwtools/abase/l5.test/Glob.test.s
+++ b/proto/dwtools/abase/l5.test/Glob.test.s
@@ -442,16 +442,36 @@ function globFilter( test )
   var got = path.globFilter( src, '(ab|bb|abc)c' );
   test.identical( got, expected );
 
-  test.case = 'pattern match = none';
-  var expected = [ ];
-  var src = [ 'a', 'b', 'bb' ];
-  var got = path.globFilter( src, 'a(b|bb|bc)' );
-  test.identical( got, expected );
-
-  test.case = 'either a or b but ending with c';
+  test.case = '2 chars starting with a or b but ending with c';
   var expected = [ 'ac' ];
   var src = [ 'ac', 'abc', 'cc' ];
   var got = path.globFilter( src, '(a|b)c' );
+  test.identical( got, expected );
+
+  // !(|)
+
+  test.case = 'not pattern match = none';
+  var expected = [ ];
+  var src = [ 'ab', 'ac' ];
+  var got = path.globFilter( src, 'a!(b|c)' );
+  test.identical( got, expected );
+
+  test.case = '3 chars starting with a, skip b-k, end with z';
+  var expected = [ 'azz' ];
+  var src = [ 'abz', 'acz', 'azz' ];
+  var got = path.globFilter( src, 'a!(b|c|d|e|f|g|h|i|j|k)z' );
+  test.identical( got, expected );
+
+  test.case = 'any 3 chars, no z in the middle';
+  var expected = [ 'abz', 'acz' ];
+  var src = [ 'abz', 'acz', 'zzz' ];
+  var got = path.globFilter( src, 'a!(z)z' );
+  test.identical( got, expected );
+
+  test.case = 'not pattern match = skip all from a to k';
+  var expected = [ 'abz', 'acz' ];
+  var src = [ 'abz', 'acz', 'azz' ];
+  var got = path.globFilter( src, 'a!(z)z' );
   test.identical( got, expected );
 
 }

--- a/proto/dwtools/abase/l5.test/Glob.test.s
+++ b/proto/dwtools/abase/l5.test/Glob.test.s
@@ -544,11 +544,9 @@ function globFilter( test )
   test.shouldThrowErrorSync(path.globFilter( null, 'lorem' ));
   test.shouldThrowErrorSync(path.globFilter( null, null ));
 
-  test.case = 'plain number';
-  var expected = [ 0 ];
+  test.case = 'plain numbers as glob must fail';
   var src = [ 0, 1, 2, 3, 4 ];
-  var got = path.globFilter( src, 0 );
-  test.identical( got, expected );
+  test.shouldThrowErrorSync( path.globFilter( src, 0 ) );
 }
 
 //


### PR DESCRIPTION
# Coverage Improvement for globFilter routine

## Why is this needed?
* To cover all the possible scenarios for `globFilter` routine
* For reviewing the standards for test cases
* To also track the correct and wrong behaviour of `globFilter` routine

## What does this do?
* This adds more test cases to test `globFilter` routine. Tests the globs:
`*` , `?`, `...`, `!(pattern|pattern|pattern)`, `?(pattern|pattern|pattern)`, `+(pattern|pattern|pattern)`, `@(pattern|pat*|pat?erN)`

* The enhanced coverage has found a few bugs which are listed under `FIXME` comment with `globFilter` routine

## Known Issues
1. The scenarios are still in progress by the contributor
1. More scenarios are expected by reviewers during the review of this PR

## References
1. Glob Doc for scenarios covered can be found [here](https://www.npmjs.com/package/glob#glob-primer) 
1. Glob testing tool for quick testing of patterns can be found [here](https://codepen.io/mrmlnc/pen/OXQjrZ)
1. This PR moved to [parent](https://github.com/Wandalen/wPathTools/pull/9). Do not review
## Who should review?
- [x] @Wandalen